### PR TITLE
Adding missing dependency for X-Pack Reporting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/ukhomeofficedigital/centos-base:v0.2.0
 
 RUN yum upgrade -y -q; yum clean all
-RUN yum install -y -q tar wget; yum clean all
+RUN yum install -y -q tar wget fontconfig; yum clean all
 RUN groupadd -r -g 1000 kibana && adduser -M -u 1000 -g 1000 kibana
 
 EXPOSE 5601


### PR DESCRIPTION
This issue should fix the below issue in Kibana, freetype is a dependency of fontconfig and installs with the fontconfig package.

"There was an error generating your report for the "ABC Dashboard" dashboard: Error: You must install fontconfig and freetype for Reporting to work"